### PR TITLE
Misleading documentation unfoldWhileM and unfoldWhileM'

### DIFF
--- a/src/Control/Monad/Loops.hs
+++ b/src/Control/Monad/Loops.hs
@@ -247,7 +247,7 @@ unfoldM' m = whileJust' m return
 unfoldM_ :: (Monad m) => m (Maybe a) -> m ()
 unfoldM_ m = whileJust_ m return
 
--- |Repeatedly evaluates the second argument until the value satisfies
+-- |Repeatedly evaluates the second argument until the value does not satisfy
 -- the given predicate, and returns a list of all values that satisfied the
 -- predicate.  Discards the final one (which failed the predicate).
 unfoldWhileM :: Monad m => (a -> Bool) -> m a -> m [a]
@@ -259,7 +259,7 @@ unfoldWhileM p m = loop id
                 then loop (f . (x:))
                 else return (f [])
 
--- |Repeatedly evaluates the second argument until the value satisfies
+-- |Repeatedly evaluates the second argument until the value does not satisfy
 -- the given predicate, and returns a 'MonadPlus' collection of all values
 -- that satisfied the predicate.  Discards the final one (which failed the predicate).
 unfoldWhileM' :: (Monad m, MonadPlus f) => (a -> Bool) -> m a -> m (f a)


### PR DESCRIPTION
"Repeatedly evaluates the second argument until the value satisfies the given predicate"
should read
""Repeatedly evaluates the second argument until the value DOES NOT satisfy the given predicate"

Testing it:
ref <- newIORef 0
unfoldWhileM (<= 5) (modifyIORef ref (+1) >> readIORef ref)

The result gives me [1,2,3,4,5], showing that the monadic computation is evaluated as long as its result passes the predicate check (so until it doesn't satisfy the predicate).