### PR TITLE
Fix docs for `unfoldWhileM` and `unfoldWhileM'`

### DIFF
--- a/src/Control/Monad/Loops.hs
+++ b/src/Control/Monad/Loops.hs
@@ -247,7 +247,7 @@ unfoldM' m = whileJust' m return
 unfoldM_ :: (Monad m) => m (Maybe a) -> m ()
 unfoldM_ m = whileJust_ m return
 
--- |Repeatedly evaluates the second argument until the value satisfies
+-- |Repeatedly evaluates the second argument while the value satisfies
 -- the given predicate, and returns a list of all values that satisfied the
 -- predicate.  Discards the final one (which failed the predicate).
 unfoldWhileM :: Monad m => (a -> Bool) -> m a -> m [a]
@@ -259,7 +259,7 @@ unfoldWhileM p m = loop id
                 then loop (f . (x:))
                 else return (f [])
 
--- |Repeatedly evaluates the second argument until the value satisfies
+-- |Repeatedly evaluates the second argument while the value satisfies
 -- the given predicate, and returns a 'MonadPlus' collection of all values
 -- that satisfied the predicate.  Discards the final one (which failed the predicate).
 unfoldWhileM' :: (Monad m, MonadPlus f) => (a -> Bool) -> m a -> m (f a)


### PR DESCRIPTION
The docs say that `unfoldWhileM` and `unfoldWhileM'` repeatedly evaluate the monadic action _until_ the predicate returns `True`, but they actually evaluate it _while_ the predicate returns `True`.