### PR TITLE
Change cabal file license to reflect LICENSE file

### DIFF
--- a/monad-loops.cabal
+++ b/monad-loops.cabal
@@ -1,7 +1,7 @@
 name:                   monad-loops
 version:                0.4.2.1
 stability:              provisional
-license:                PublicDomain
+license:                BSD-3
 
 cabal-version:          >= 1.8
 build-type:             Simple


### PR DESCRIPTION
I presume declaring this license was the original intention, given the existence of the LICENSE file at all.

Should resolve issue https://github.com/mokus0/monad-loops/issues/17.